### PR TITLE
Fold source and destination into (*page.Page).Load()

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -5,10 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/aedipamoss/stationery/config"
-	"github.com/aedipamoss/stationery/fileutils"
 	"github.com/aedipamoss/stationery/page"
 )
 
@@ -26,20 +24,6 @@ func sourceFiles(source string) (files []os.FileInfo, err error) {
 	return files, err
 }
 
-func source(path string, file os.FileInfo) string {
-	name := file.Name()
-	file, err := os.Stat(path)
-	if err != nil {
-		return name
-	}
-
-	if !file.IsDir() {
-		return name
-	}
-
-	return filepath.Join(path, name)
-}
-
 func generateFiles(config config.Config) error {
 	var err error
 
@@ -52,14 +36,9 @@ func generateFiles(config config.Config) error {
 		page := &page.Page{}
 		page.Assets = config.Assets
 		page.FileInfo = file
-
-		basename := fileutils.Basename(file)
-		page.Destination = filepath.Join(config.Output, basename+".html")
-
-		page.Source = source(config.Source, file)
 		page.Template = config.Template
 
-		err = page.Load()
+		err = page.Load(config.Source, config.Output)
 		if err != nil {
 			return err
 		}

--- a/page/page.go
+++ b/page/page.go
@@ -7,9 +7,11 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/aedipamoss/stationery/assets"
+	"github.com/aedipamoss/stationery/fileutils"
 	blackfriday "gopkg.in/russross/blackfriday.v2"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -113,9 +115,42 @@ func (page *Page) parseContent() error {
 	return nil
 }
 
+func (page *Page) setSource(src string) error {
+	name := page.FileInfo.Name()
+	file, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if !file.IsDir() {
+		page.Source = name
+		return nil
+	}
+
+	page.Source = filepath.Join(src, name)
+	return nil
+}
+
+func (page *Page) setDestination(dest string) error {
+	basename := fileutils.Basename(page.FileInfo)
+	page.Destination = filepath.Join(dest, basename+".html")
+
+	return nil
+}
+
 // Load reads the page from source and parses the content and front-matter into data.
-func (page *Page) Load() error {
-	err := page.parseRaw()
+func (page *Page) Load(src string, dest string) error {
+	err := page.setSource(src)
+	if err != nil {
+		return err
+	}
+
+	err = page.setDestination(dest)
+	if err != nil {
+		return err
+	}
+
+	err = page.parseRaw()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While this adds more logic into load, it makes generate much simpler
and since that's where we'll be adding more stuff like generating an
index page and rss feed, etc. I want to keep it small.

Also, it seemed unnecessary to have a private method in one class,
that sets an attribute on an instance which is used inside a private
function within that namespace. Maybe those words don't quite explain
it well enough, but for sure it was confusing.

My goal from here is to make generation load files at once into a
slice that I can iterate over as many times as I wish for example
sorting by date and writing an archive page, or generating RSS.