### PR TITLE
Output tags to their own dir

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -9,6 +9,7 @@ import (
 
 // List is a struct containing all the CSS, JavaScript, and Images to be built.
 type List struct {
+	Prefix string
 	CSS    []string
 	JS     []string
 	Images []string
@@ -20,7 +21,7 @@ const Template = `
 {{ define "assets" }}
   {{ if (exists "CSS" .Assets) }}
     {{ range .Assets.CSS }}
-      <link type="text/css" rel="stylesheet" href="css/{{ . }}">
+      <link type="text/css" rel="stylesheet" href="{{ $.Assets.Prefix }}css/{{ . }}">
     {{ end }}
   {{ end }}
 {{ end }}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -130,11 +130,17 @@ func buildTagsTree(pages []*page.Page) map[string][]*page.Page {
 func generateTags(pages []*page.Page) error {
 	tree := buildTagsTree(pages)
 
+	err := os.MkdirAll(filepath.Join(cfg.Output, "tag"), 0700)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	for tag, ps := range tree {
 		p := &page.Page{}
 		p.Assets = cfg.Assets
+		p.Assets.Prefix = "../"
 		p.Data.Title = cfg.Title
-		p.Destination = filepath.Join(cfg.Output, fmt.Sprintf("tag-%s.html", tag))
+		p.Destination = filepath.Join(cfg.Output, "tag", fmt.Sprintf("%s.html", tag))
 		p.Template = filepath.Join("layouts", "index.html")
 		p.Children = ps
 


### PR DESCRIPTION
This required a change to assets template to support prefixes,
in order to still load assets from within a subdir.