### PR TITLE
Use absolute paths when creating links

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -9,7 +9,6 @@ import (
 
 // List is a struct containing all the CSS, JavaScript, and Images to be built.
 type List struct {
-	Prefix string
 	CSS    []string
 	JS     []string
 	Images []string
@@ -21,7 +20,7 @@ const Template = `
 {{ define "assets" }}
   {{ if (exists "CSS" .Assets) }}
     {{ range .Assets.CSS }}
-      <link type="text/css" rel="stylesheet" href="{{ $.Assets.Prefix }}css/{{ . }}">
+      <link type="text/css" rel="stylesheet" href="{{ $.Root }}css/{{ . }}">
     {{ end }}
   {{ end }}
 {{ end }}

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,9 @@ type Config struct {
 	Output  string
 	Source  string
 	Layouts []string
+	SiteURL string
 	// RSS fields
 	Title       string
-	Link        string
 	Description string
 	Name        string
 	Email       string

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/aedipamoss/stationery/config"
 	"github.com/aedipamoss/stationery/page"
@@ -15,6 +16,18 @@ import (
 )
 
 var cfg config.Config
+
+func rootURI() string {
+	if cfg.SiteURL != "" {
+		return strings.TrimRight(cfg.SiteURL, "/") + "/"
+	} else {
+		path, err := filepath.Abs(cfg.Output)
+		if err != nil {
+			panic(err)
+		}
+		return strings.TrimRight(path, "/") + "/"
+	}
+}
 
 // Returns a list of pages sorted by date
 func load(source string) (pages []*page.Page, err error) {
@@ -40,6 +53,7 @@ func load(source string) (pages []*page.Page, err error) {
 		page := &page.Page{}
 		page.Assets = cfg.Assets
 		page.FileInfo = file
+		page.Root = rootURI()
 		page.Template = filepath.Join("layouts", "page.html")
 
 		err := page.Load(cfg.Source, cfg.Output)
@@ -71,7 +85,7 @@ func generateHTML(pages []*page.Page) error {
 func generateRSS(pages []*page.Page) error {
 	feed := feeds.Feed{
 		Title:       cfg.Title,
-		Link:        &feeds.Link{Href: cfg.Link},
+		Link:        &feeds.Link{Href: cfg.SiteURL},
 		Description: cfg.Description,
 		Author:      &feeds.Author{Name: cfg.Name, Email: cfg.Email},
 	}
@@ -79,7 +93,7 @@ func generateRSS(pages []*page.Page) error {
 	for _, page := range pages {
 		feed.Add(&feeds.Item{
 			Title:       page.Title(),
-			Link:        &feeds.Link{Href: page.URL(cfg)},
+			Link:        &feeds.Link{Href: page.URL()},
 			Description: page.Description(),
 			Author:      &feeds.Author{Name: cfg.Name, Email: cfg.Email},
 			Created:     page.Date(),
@@ -100,6 +114,7 @@ func generateRSS(pages []*page.Page) error {
 func generateIndex(pages []*page.Page) error {
 	index := &page.Page{}
 	index.Assets = cfg.Assets
+	index.Root = rootURI()
 	index.Data.Title = cfg.Title
 	index.Destination = filepath.Join(cfg.Output, "index.html")
 	index.Template = filepath.Join("layouts", "index.html")
@@ -138,7 +153,7 @@ func generateTags(pages []*page.Page) error {
 	for tag, ps := range tree {
 		p := &page.Page{}
 		p.Assets = cfg.Assets
-		p.Assets.Prefix = "../"
+		p.Root = rootURI()
 		p.Data.Title = cfg.Title
 		p.Destination = filepath.Join(cfg.Output, "tag", fmt.Sprintf("%s.html", tag))
 		p.Template = filepath.Join("layouts", "index.html")

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -18,15 +18,20 @@ import (
 var cfg config.Config
 
 func rootURI() string {
+	var path string
+	var err error
+
 	if cfg.SiteURL != "" {
-		return strings.TrimRight(cfg.SiteURL, "/") + "/"
+		path = strings.TrimRight(cfg.SiteURL, "/") + "/"
 	} else {
-		path, err := filepath.Abs(cfg.Output)
+		path, err = filepath.Abs(cfg.Output)
 		if err != nil {
 			panic(err)
 		}
-		return strings.TrimRight(path, "/") + "/"
+		path = strings.TrimRight(path, "/") + "/"
 	}
+
+	return path
 }
 
 // Returns a list of pages sorted by date


### PR DESCRIPTION
This resolves an issue where links to tags, of a page, from a tag
page... was causing a nesting issue.

Because it was using relative links until now.

If we want to keep using relative links, that would require creating
some kind of tree for pages to know how deeply nested they are, in
order to generate the proper links to assets and other places.

This solves the issue by allowing a page to always know the root.

It depends on whether config.SiteURL is filled out, and you probably
don't want to fill it out when testing local generation.

In that case use a blank string, or leave it empty, and all the links
will be fully resolved to wherever the output directory is.